### PR TITLE
Hotfix: Add GitHub Skills activity (fixes #6)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -33,6 +33,12 @@ activities = {
         "max_participants": 20,
         "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub (certifications).",
+        "schedule": "Fridays, 1:00 PM - 2:30 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Gym Class": {
         "description": "Physical education and sports activities",
         "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",


### PR DESCRIPTION
Adds the "GitHub Skills" activity so students can register immediately.

This is a small, low-risk hotfix that updates the in-memory activities list.

Closes #6.